### PR TITLE
Move JVM options to the right location

### DIFF
--- a/install-tomcat.sh
+++ b/install-tomcat.sh
@@ -8,4 +8,3 @@ mv start-tomcat.sh /usr/local/bin/
 find . -name '*.war' -exec mv {} /var/lib/tomcat7/webapps/ \;
 sudo -u tomcat7 -g tomcat7 mkdir /tmp/tomcat7-tomcat7-tmp
 sed -i "/^shared\.loader=/c\shared.loader=/var/lib/tomcat7/shared/classes,/var/lib/tomcat7/shared/*.jar,/etc/osiam" /etc/tomcat7/catalina.properties
-sed -i "/^JAVA_OPTS=/c\JAVA_OPTS=\"-Djava.awt.headless=true -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024m\"" /etc/default/tomcat7

--- a/start-tomcat.sh
+++ b/start-tomcat.sh
@@ -8,5 +8,5 @@ fi
 exec sudo -u tomcat7 -g tomcat7 \
     CATALINA_BASE=/var/lib/tomcat7 \
     CATALINA_TMPDIR=/tmp/tomcat7-tomcat7-tmp \
+    CATALINA_OPTS="-Djava.awt.headless=true -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024m" \
     /usr/share/tomcat7/bin/catalina.sh $DEBUG_COMMAND run
-


### PR DESCRIPTION
Currently we put our custom JVM options into the `/etc/default/tomcat7`.  That's obviously wrong, because we don't start Tomcat via SysVinit, but directly with `catalina.sh`. So this commits adds the respective environment variable to the call to `catalina.sh` and removes the change of `JAVA_OPTS` in `/etc/default/tomcat7`.