### PR TITLE
Update runtime to Java8, Tomcat8 and Debian Jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # OSIAM
 
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER tarent solutions GmbH <info@tarent.de>
 
 # update/install packages
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+         /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --force-yes && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --force-yes \
-        openjdk-7-jdk tomcat7 postgresql-9.1 sudo curl supervisor unzip vim-tiny less git
+        openjdk-8-jdk tomcat8 postgresql-9.4 sudo curl supervisor unzip vim-tiny less git
 
 # install OSIAM
 COPY . /install/

--- a/install-3rdparty.sh
+++ b/install-3rdparty.sh
@@ -13,8 +13,8 @@ ln -s /opt/flyway/flyway /usr/local/bin/flyway
 
 # install greenmail webapp to provide simple smtp service for the self-administration and administration
 curl -o greenmail.war http://central.maven.org/maven2/com/icegreen/greenmail-webapp/1.4.1/greenmail-webapp-1.4.1.war
-unzip greenmail.war -d /var/lib/tomcat7/webapps/greenmail
-sed -i 's/127.0.0.1/0.0.0.0/g' /var/lib/tomcat7/webapps/greenmail/WEB-INF/web.xml
+unzip greenmail.war -d /var/lib/tomcat8/webapps/greenmail
+sed -i 's/127.0.0.1/0.0.0.0/g' /var/lib/tomcat8/webapps/greenmail/WEB-INF/web.xml
 
 # install maven
 MAVEN_VERSION=3.3.3

--- a/install-database.sh
+++ b/install-database.sh
@@ -4,14 +4,14 @@ set -e
 
 # setup database
 useradd -M -s /bin/false -U ong
-echo "local all all           md5" >> /etc/postgresql/9.1/main/pg_hba.conf
-echo "host  all all 0.0.0.0/0 md5" >> /etc/postgresql/9.1/main/pg_hba.conf
-echo "listen_addresses='*'" >> /etc/postgresql/9.1/main/postgresql.conf
-rm -f /var/lib/postgresql/9.1/main/server.crt
-cp /etc/ssl/certs/ssl-cert-snakeoil.pem /var/lib/postgresql/9.1/main/server.crt
-rm -f /var/lib/postgresql/9.1/main/server.key
-cp /etc/ssl/private/ssl-cert-snakeoil.key /var/lib/postgresql/9.1/main/server.key
-chown postgres:postgres /var/lib/postgresql/9.1/main/server.crt /var/lib/postgresql/9.1/main/server.key
+echo "local all all           md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+echo "host  all all 0.0.0.0/0 md5" >> /etc/postgresql/9.4/main/pg_hba.conf
+echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
+rm -f /var/lib/postgresql/9.4/main/server.crt
+cp /etc/ssl/certs/ssl-cert-snakeoil.pem /var/lib/postgresql/9.4/main/server.crt
+rm -f /var/lib/postgresql/9.4/main/server.key
+cp /etc/ssl/private/ssl-cert-snakeoil.key /var/lib/postgresql/9.4/main/server.key
+chown postgres:postgres /var/lib/postgresql/9.4/main/server.crt /var/lib/postgresql/9.4/main/server.key
 
 /etc/init.d/postgresql start
 

--- a/install-tomcat.sh
+++ b/install-tomcat.sh
@@ -5,6 +5,6 @@ set -e
 mv start-tomcat.sh /usr/local/bin/
 
 # setup tomcat
-find . -name '*.war' -exec mv {} /var/lib/tomcat7/webapps/ \;
-sudo -u tomcat7 -g tomcat7 mkdir /tmp/tomcat7-tomcat7-tmp
-sed -i "/^shared\.loader=/c\shared.loader=/var/lib/tomcat7/shared/classes,/var/lib/tomcat7/shared/*.jar,/etc/osiam" /etc/tomcat7/catalina.properties
+find . -name '*.war' -exec mv {} /var/lib/tomcat8/webapps/ \;
+sudo -u tomcat8 -g tomcat8 mkdir /tmp/tomcat8-tomcat8-tmp
+sed -i "/^shared\.loader=/c\shared.loader=/var/lib/tomcat8/shared/classes,/var/lib/tomcat8/shared/*.jar,/etc/osiam" /etc/tomcat8/catalina.properties

--- a/start-tomcat.sh
+++ b/start-tomcat.sh
@@ -5,8 +5,8 @@ if [ -n "$DEBUG" ]; then
   DEBUG_COMMAND=jpda
 fi
 
-exec sudo -u tomcat7 -g tomcat7 \
-    CATALINA_BASE=/var/lib/tomcat7 \
-    CATALINA_TMPDIR=/tmp/tomcat7-tomcat7-tmp \
+exec sudo -u tomcat8 -g tomcat8 \
+    CATALINA_BASE=/var/lib/tomcat8 \
+    CATALINA_TMPDIR=/tmp/tomcat8-tomcat8-tmp \
     CATALINA_OPTS="-Djava.awt.headless=true -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024m" \
-    /usr/share/tomcat7/bin/catalina.sh $DEBUG_COMMAND run
+    /usr/share/tomcat8/bin/catalina.sh $DEBUG_COMMAND run

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:postgres]
-command=sudo -u postgres /usr/lib/postgresql/9.1/bin/postgres -D /var/lib/postgresql/9.1/main -c config_file=/etc/postgresql/9.1/main/postgresql.conf
+command=sudo -u postgres /usr/lib/postgresql/9.4/bin/postgres -D /var/lib/postgresql/9.4/main -c config_file=/etc/postgresql/9.4/main/postgresql.conf
 
-[program:tomcat7]
+[program:tomcat8]
 command=/usr/local/bin/start-tomcat.sh


### PR DESCRIPTION
In preparation to upgrade the java dependencies of OSIAM to version 8
this commit updates the docker image to Debian jessie and uses Java 8
from the backports repository. It also upgrades the installed Tomcat to
version 8 and the used PostgreSQL database to 9.4.

This pull request has to be merged before work can start on the issue
osiam/osiam#10