### PR TITLE
Use new way of deployment for OSIAM

### DIFF
--- a/install-configuration.sh
+++ b/install-configuration.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+mkdir /var/lib/osiam
+mv osiam/src/main/deploy/* /var/lib/osiam
+
 mkdir /etc/osiam
-mv osiam/src/main/deploy/* /etc/osiam
 mv addon-self-administration/src/main/deploy/* /etc/osiam
 mv addon-administration/src/main/deploy/* /etc/osiam
 

--- a/install-tomcat.sh
+++ b/install-tomcat.sh
@@ -5,6 +5,7 @@ set -e
 mv start-tomcat.sh /usr/local/bin/
 
 # setup tomcat
+cp osiam.xml /var/lib/tomcat8/conf/Catalina/localhost/osiam.xml
 find . -name '*.war' -exec mv {} /var/lib/tomcat8/webapps/ \;
 sudo -u tomcat8 -g tomcat8 mkdir /tmp/tomcat8-tomcat8-tmp
 sed -i "/^shared\.loader=/c\shared.loader=/var/lib/tomcat8/shared/classes,/var/lib/tomcat8/shared/*.jar,/etc/osiam" /etc/tomcat8/catalina.properties

--- a/osiam.xml
+++ b/osiam.xml
@@ -1,0 +1,3 @@
+<Context>
+    <Environment name="osiam.home" value="/var/lib/osiam" type="java.lang.String"/>
+</Context>


### PR DESCRIPTION
OSIAM now loads assets and configuration from a directory in the
file system known as `OSIAM_HOME`.
Add a Tomcat deployment descriptor to set the home directory for the
deployment.
Put the home directory under `/var/lib/osiam`, because it fits quite
nicely there.
This is also the home directory used in the official docs.