### PR TITLE
Fix Tomcat debugging

### DIFF
--- a/start-tomcat.sh
+++ b/start-tomcat.sh
@@ -9,4 +9,5 @@ exec sudo -u tomcat8 -g tomcat8 \
     CATALINA_BASE=/var/lib/tomcat8 \
     CATALINA_TMPDIR=/tmp/tomcat8-tomcat8-tmp \
     CATALINA_OPTS="-Djava.awt.headless=true -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024m" \
+    JPDA_ADDRESS=8000 \
     /usr/share/tomcat8/bin/catalina.sh $DEBUG_COMMAND run


### PR DESCRIPTION
In Tomcat 8 the default bind address for the JPDA port changed to
localhost.
Set to ANYNET, like before, by specifying no bind address at all.