### PR TITLE
Fix OSIAM endpoint config for self-administration

### DIFF
--- a/addon-self-administration.properties
+++ b/addon-self-administration.properties
@@ -1,3 +1,4 @@
 org.osiam.mail.server.username=user1
 org.osiam.mail.server.password=password
 org.osiam.mail.server.smtp.port=10025
+org.osiam.home=http://localhost:8080/osiam


### PR DESCRIPTION
The self-administration's default config only defines endpoint
configuration for OSIAM 2.x.
As the Docker image uses the default config, the self-administration
doesn't work.
This commit adds the endpoint config for OSIAM 3.0 that takes precedence
over the default config and therefore makes the self-administration work
again.