### PR TITLE
Replace running Flyway with running migrateDB command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ only! Do not even think about using it in a production-like environment!
 * full postgres database already installed
 * default sample data included
 * running greenmail fake mail server to provide fully functional addons
-* a few dev tools are included for convenience: maven, flyway, git, less, vim,
+* a few dev tools are included for convenience: maven, git, less, vim,
   openjdk7-jdk, curl, unzip
 
 ## Use the image

--- a/flyway.conf
+++ b/flyway.conf
@@ -1,5 +1,0 @@
-flyway.url=jdbc:postgresql://localhost:5432/osiam
-flyway.user=osiam
-flyway.password=osiam
-flyway.baselineVersion=0
-flyway.baselineOnMigrate=true

--- a/install-3rdparty.sh
+++ b/install-3rdparty.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-# install flyway
-FLYWAY_VERSION=3.2.1
-curl -o flyway.tgz http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz
-tar -xzf flyway.tgz
-mv flyway-${FLYWAY_VERSION} /opt/flyway
-mv -f flyway.conf /opt/flyway/conf/flyway.conf
-chmod +x /opt/flyway/flyway
-ln -s /opt/flyway/flyway /usr/local/bin/flyway
-
 # install greenmail webapp to provide simple smtp service for the self-administration and administration
 curl -o greenmail.war http://central.maven.org/maven2/com/icegreen/greenmail-webapp/1.4.1/greenmail-webapp-1.4.1.war
 unzip greenmail.war -d /var/lib/tomcat8/webapps/greenmail

--- a/install-database.sh
+++ b/install-database.sh
@@ -19,11 +19,7 @@ echo "CREATE USER osiam WITH PASSWORD 'osiam';" | sudo -u postgres psql
 echo "CREATE DATABASE osiam;" | sudo -u postgres psql
 echo "GRANT ALL PRIVILEGES ON DATABASE osiam TO osiam;" | sudo -u postgres psql
 
-mkdir -p migrations/osiam
-cp osiam/target/osiam-classes.jar migrations/osiam
-flyway -locations=db/migration/postgresql/ \
-    -jarDirs=./migrations/osiam \
-    migrate
+java -jar osiam/target/osiam.war migrateDb --osiam.home=/var/lib/osiam
 
 # import addon setup data
 sudo -u osiam psql -f example-data.sql


### PR DESCRIPTION
Now that OSIAM understands the `migrateDb` command, running Flyway
manually to create the initial database schema is not necessary anymore.
It also reduces image build time and size, and enables us to use
programmatic migrations based on Spring's `JdbcTemplate`.